### PR TITLE
Change endpoint for bike lane reports to be our API

### DIFF
--- a/common/fetch311.js
+++ b/common/fetch311.js
@@ -1,0 +1,46 @@
+import axios from "axios"
+
+function aMonthAgo(date) {
+  const day1 = Date.parse('25 Aug 2018 00:00:00 GMT')
+  const day2 = Date.parse('25 Jul 2018 00:00:00 GMT')
+  return new Date(date - (day1 - day2));
+}
+
+module.exports = {
+  fetch311: async function() {
+    const base_url = 'https://lane-breach.herokuapp.com/api/sf311_cases'
+    var today = new Date();
+    const url_filters = [
+      ['start_time', aMonthAgo(today).toISOString().substring(0, 10)],
+      ['end_time', today.toISOString().substring(0, 10)],
+      ['per_page', 500]
+    ];
+
+    var url = base_url;
+    for (var i = 0; i < url_filters.length; i++) {
+      var sep = '&';
+      if (i == 0) { sep = '?' }
+      url += sep + url_filters[i][0] + '=' + url_filters[i][1];
+    }
+
+    const { data: bikeLaneReports } = await axios.get(url);
+
+    const formattedData = {
+      "type": "FeatureCollection",
+      "features": bikeLaneReports.data.map((report, i) => ({
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [report.long, report.lat],
+        },
+        properties: {
+          title: `Point${i}`,
+          icon: "harbor",
+          color: "#FFFFFF"
+        }
+      }))
+    };
+
+    return formattedData;
+  }  // fetch311
+};

--- a/common/fetchData.js
+++ b/common/fetchData.js
@@ -1,0 +1,46 @@
+import axios from "axios"
+
+function aMonthAgo(date) {
+  const day1 = Date.parse('25 Aug 2018 00:00:00 GMT')
+  const day2 = Date.parse('25 Jul 2018 00:00:00 GMT')
+  return new Date(date - (day1 - day2));
+}
+
+module.exports = {
+  fetch311: async function() {
+    const base_url = 'https://lane-breach.herokuapp.com/api/sf311_cases'
+    var today = new Date();
+    const url_filters = [
+      ['start_time', aMonthAgo(today).toISOString().substring(0, 10)],
+      ['end_time', today.toISOString().substring(0, 10)],
+      ['per_page', 500]
+    ];
+
+    var url = base_url;
+    for (var i = 0; i < url_filters.length; i++) {
+      var sep = '&';
+      if (i == 0) { sep = '?' }
+      url += sep + url_filters[i][0] + '=' + url_filters[i][1];
+    }
+
+    const { data: bikeLaneReports } = await axios.get(url);
+
+    const formattedData = {
+      "type": "FeatureCollection",
+      "features": bikeLaneReports.data.map((report, i) => ({
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [report.long, report.lat],
+        },
+        properties: {
+          title: `Point${i}`,
+          icon: "harbor",
+          color: "#FFFFFF"
+        }
+      }))
+    };
+
+    return formattedData;
+  }  // fetch311
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dc:prune": "docker system prune --all --force --volumes",
     "dev": "concurrently \"yarn dev:app\" \"yarn dev:server\"",
     "dev:app": "webpack-dev-server --config webpack/frontend.dev",
-    "dev:server": "nodemon --legacy-watch --exec babel-node ./server/index.js --watch ./server",
+    "dev:server": "nodemon --legacy-watch --exec babel-node ./server/index.js --watch ./server --watch ./common",
     "prod:build": "yarn prod:clear && webpack --config webpack/frontend.prod.js && webpack --config webpack/backend.prod.js",
     "prod:start": "yarn prod:build && yarn prod:run",
     "prod:run": "node public/dist/bundle-backend.js",

--- a/server/api.js
+++ b/server/api.js
@@ -1,46 +1,11 @@
 import express from "express";
-import axios from "axios"
 
 const API = express.Router();
 
-function aMonthAgo(date) {
-  const day1 = Date.parse('25 Aug 2018 00:00:00 GMT')
-  const day2 = Date.parse('25 Jul 2018 00:00:00 GMT')
-  return new Date(date - (day1 - day2));
-}
+const dataFetcher = require('../common/fetchData.js');
 
 API.get("/reports",  async (req, res) => {
-  const base_url = 'https://lane-breach.herokuapp.com/api/sf311_cases'
-  var today = new Date();
-  const url_filters = [ ['start_time', aMonthAgo(today).toISOString().substring(0, 10)],
-                        ['end_time', today.toISOString().substring(0, 10)],
-                        ['per_page', 500]
-                      ]
-  var url = base_url;
-  for (var i = 0; i < url_filters.length; i++) {
-    var sep = '&';
-    if (i == 0) { sep = '?' }
-    url += sep + url_filters[i][0] + '=' + url_filters[i][1];
-  }
-
-  const { data: bikeLaneReports } = await axios.get(url);
-
-  const formattedData = {
-    "type": "FeatureCollection",
-    "features": bikeLaneReports.data.map((report, i) => ({
-      type: "Feature",
-      geometry: {
-        type: "Point",
-        coordinates: [report.long, report.lat],
-      },
-      properties: {
-        title: `Point${i}`,
-        icon: "harbor",
-        color: "#FFFFFF"
-      }
-    }))
-  };
-  res.status(200).send(formattedData)
+  res.status(200).send(await dataFetcher.fetch311())
 });
 
 export default API;

--- a/server/api.js
+++ b/server/api.js
@@ -3,23 +3,35 @@ import axios from "axios"
 
 const API = express.Router();
 
+function aMonthAgo(date) {
+  const day1 = Date.parse('25 Aug 2018 00:00:00 GMT')
+  const day2 = Date.parse('25 Jul 2018 00:00:00 GMT')
+  return new Date(date - (day1 - day2));
+}
+
 API.get("/reports",  async (req, res) => {
-  const base_url = 'https://data.sfgov.org/resource/ktji-gk7t.json'
-  const url_filters = [['service_subtype', 'Blocking_Bicycle_Lane']]
+  const base_url = 'https://lane-breach.herokuapp.com/api/sf311_cases'
+  var today = new Date();
+  const url_filters = [ ['start_time', aMonthAgo(today).toISOString().substring(0, 10)],
+                        ['end_time', today.toISOString().substring(0, 10)],
+                        ['per_page', 500]
+                      ]
   var url = base_url;
   for (var i = 0; i < url_filters.length; i++) {
     var sep = '&';
     if (i == 0) { sep = '?' }
     url += sep + url_filters[i][0] + '=' + url_filters[i][1];
   }
+
   const { data: bikeLaneReports } = await axios.get(url);
+
   const formattedData = {
     "type": "FeatureCollection",
-    "features": bikeLaneReports.map((report, i) => ({
+    "features": bikeLaneReports.data.map((report, i) => ({
       type: "Feature",
       geometry: {
         type: "Point",
-        coordinates: report.point.coordinates,
+        coordinates: [report.long, report.lat],
       },
       properties: {
         title: `Point${i}`,

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -65,40 +65,43 @@ export default class Map extends React.Component {
     );
   }
 
-  buildMapStyle(){
+  buildMapStyle() {
     var map_style = this.map.getStyle();
-      map_style.sources.sf311 = {
-        "type": "geojson",
-        "data": this.state.bike_lane_reports
-      };
+    map_style.sources.sf311 = {
+      "type": "geojson",
+      "data": this.state.bike_lane_reports
+    };
 
-      // Uncomment to make data underneath other data.
-      // map_style.layers.unshift({
+    // Uncomment to make data underneath other data.
+    // map_style.layers.unshift({
 
-      map_style.layers.push({
-        "id": "points",
-        "type": "heatmap",
-        "source": "sf311",
-        "paint": {
-          "heatmap-radius": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            0, 2,
-            9, 6
-          ], 
-        }
-      });
+    map_style.layers.push({
+      "id": "points",
+      "type": "heatmap",
+      "source": "sf311",
+      "paint": {
+        "heatmap-radius": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0, 2,
+          9, 6
+        ], 
+      }
+    });
       
-      map_style.layers = map_style.layers.filter(layer => {
-        if(layer.id == "bike-lane-reports-point")   return false;
-        if(layer.id == "bike-lane-reports-heat")    return false;
-        if(layer.id == "bike-injdeath-with-coords") return false;
-        if(layer.id == "bike-injdeath-derived")     return false;
-        return true;
-      });
-      return map_style;
+    map_style.layers = map_style.layers.filter(layer => {
+      if(layer.id == "bike-lane-reports")         return false;
+      if(layer.id == "bike-lane-reports-point")   return false;
+      if(layer.id == "bike-lane-reports-heat")    return false;
+      if(layer.id == "bike-injdeath-with-coords") return false;
+      if(layer.id == "bike-injdeath-derived")     return false;
+      return true;
+    });
+
+    return map_style;
   }
+
   addPopup(incident) {
     const { coordinates }  = incident.geometry;
     const placeholder = document.createElement("div");


### PR DESCRIPTION
We can actually poke our own [existing API](https://github.com/lanebreach/lanebreach-api) to grab bike lane reports rather than pinging 311 all the time.