### PR TITLE
Update ISC license references to MIT, matching root directory.

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Timothy Shoaf <tim@timshoaf.dev>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --config webpack/frontend.prod.js --mode production"
   },
   "author": "Timothy Shoaf <tim@timshoaf.dev>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "axios": "^0.18.0",
     "d3": "^5.9.2",

--- a/src/package.json
+++ b/src/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/lanebreach/frontend.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/lanebreach/frontend/issues"
   },


### PR DESCRIPTION
Several subdirectories claim an ISC license, rather than matching the MIT license in the root directory: https://github.com/lanebreach/frontend/blob/master/LICENSE.md. Assuming that's just an accident from npm's default, and to avoid any ambiguity, I've updated those references here.